### PR TITLE
fix: исправлена конфигурация Kafka в docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,6 +82,7 @@ services:
     ports:
       - "29092:29092"
     environment:
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_NODE_ID: 1
       KAFKA_PROCESS_ROLES: "broker,controller"
       KAFKA_LISTENERS: >


### PR DESCRIPTION
Исправлена конфигурация Kafka в docker-compose.yml: 
- установлен KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1 для корректной работы consumer в Profile Service
