### PR TITLE
feat Добавил Mentor Service для запуска из локального стека

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,6 +85,15 @@ services:
       - "8084:8080"
     restart: unless-stopped
 
+  mentor-service:
+    image: ghcr.io/it-mentor-community-platform/mentor-service:dev
+    container_name: local-stack-mentor-service
+    environment:
+      - SPRING_PROFILES_ACTIVE=local-stack
+    ports:
+      - "8085:8080"
+    restart: unless-stopped
+
   kafka:
     image: apache/kafka:3.7.0
     container_name: local-stack-kafka

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,7 +86,7 @@ services:
     restart: unless-stopped
 
   mentor-service:
-    image: ghcr.io/it-mentor-community-platform/mentor-service:dev
+    image: ghcr.io/it-mentor-community-platform/mentor-service/mentor-service:dev
     container_name: local-stack-mentor-service
     environment:
       - SPRING_PROFILES_ACTIVE=local-stack

--- a/docker/init.sql
+++ b/docker/init.sql
@@ -1,3 +1,4 @@
 CREATE SCHEMA IF NOT EXISTS auth_service;
 CREATE SCHEMA IF NOT EXISTS profile_service;
 CREATE SCHEMA IF NOT EXISTS project_service;
+CREATE SCHEMA IF NOT EXISTS mentor_service;


### PR DESCRIPTION
При запуске local-stack с чистым volume Postgres создаёт схему mentor_service, сервис успешно стартует, подключается к БД и применяет миграции