### PR TITLE
feat: add metrics for mentor-service

### DIFF
--- a/prometheus.yml
+++ b/prometheus.yml
@@ -20,6 +20,11 @@ scrape_configs:
     static_configs:
       - targets: ['data-importer:8080']
 
+  - job_name: 'mentor-service'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: [ 'mentor-service:8080' ]
+
   - job_name: 'profile-service'
     metrics_path: '/actuator/prometheus'
     static_configs:


### PR DESCRIPTION
Обновил: prometheus.yaml добавив информацию по забору метрик из сервиса: mentor-service

Проверил: 
Prometheus → Targets: mentor-service job "UP"
                      → /metrics - присутствует
Grafana → Explore → Prometheus:
   up{job="mentor-service"} возвращает 1
   jvm_memory_used_bytes{job="mentor-service"} возвращает данные